### PR TITLE
Fix mango_leaves loot table

### DIFF
--- a/src/main/resources/data/simplemango/loot_tables/blocks/mango_leaves.json
+++ b/src/main/resources/data/simplemango/loot_tables/blocks/mango_leaves.json
@@ -12,7 +12,7 @@
               "type": "minecraft:item",
               "conditions": [
                 {
-                  "condition": "minecraft:alternative",
+                  "condition": "minecraft:any_of",
                   "terms": [
                     {
                       "condition": "minecraft:match_tool",
@@ -38,7 +38,7 @@
                   ]
                 }
               ],
-              "name": "simplemango:seed"
+              "name": "simplemango:mango_leaves"
             },
             {
               "type": "minecraft:item",
@@ -103,7 +103,7 @@
         {
           "condition": "minecraft:inverted",
           "term": {
-            "condition": "minecraft:alternative",
+            "condition": "minecraft:any_of",
             "terms": [
               {
                 "condition": "minecraft:match_tool",
@@ -160,7 +160,7 @@
         {
           "condition": "minecraft:inverted",
           "term": {
-            "condition": "minecraft:alternative",
+            "condition": "minecraft:any_of",
             "terms": [
               {
                 "condition": "minecraft:match_tool",


### PR DESCRIPTION
The loot table for mango_leaves used `minecraft:alternative` instead of `minecraft:any_of` in some conditions, which broke it meaning mango leaves wouldn't drop anything. I've also changed it to drop mango leaves instead of mango seeds when silk touch is used, which I thought would be intended behaviour.

Fixes #10, fixes #11.